### PR TITLE
Enable debugging (do not merge)

### DIFF
--- a/gulp/nodemon.js
+++ b/gulp/nodemon.js
@@ -32,6 +32,10 @@ gulp.task('server', function () {
   nodemon({
     watch: ['.env', '**/*.js', '**/*.json'],
     script: 'listen-on-port.js',
+    ext: 'js',
+    execMap: {
+      js: 'node --inspect-brk'
+    },
     ignore: [
       config.paths.public + '*',
       config.paths.assets + '*',


### PR DESCRIPTION
## Enable debugging

After running `npm start` the app will pause with a `Starting inspector on 127.0.0.1:9229` message. The open a tab in chrome for the following address "chrome://inspect/#devices" and then click on the "Open dedicated DevTools for Node" link on the inspect page.

The debugger will then launch and pause on the very first line of code of the app. 
